### PR TITLE
Fix shared image resolving

### DIFF
--- a/lib/roger_themes/middleware.rb
+++ b/lib/roger_themes/middleware.rb
@@ -2,6 +2,8 @@ require File.dirname(__FILE__) + "/shared_folders"
 
 module RogerThemes
   class Middleware
+    attr_accessor :project
+
     def initialize(app, options = {})
       @app = app
 
@@ -29,7 +31,7 @@ module RogerThemes
       ret = @app.call(env)
 
       # Fallback for shared images
-      unless ret[0] == 200
+      if ret[0] == 404
 
         shared_path = @shared_folders.local_to_shared_path(path)
 

--- a/test/fixture/html/themes/my-awesome-theme/index.html
+++ b/test/fixture/html/themes/my-awesome-theme/index.html
@@ -1,0 +1,1 @@
+<h1>My awesome theme index file!</h1>

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,16 +1,41 @@
 require "test_helper"
+require "rack/mock"
+require "roger/testing/mock_project"
+
 require "./lib/roger_themes/middleware"
 
-require "rack/mock"
+class MockApp
+  attr_reader :call_stack
+  attr_writer :return_value
+
+  def initialize()
+    @call_stack = []
+
+    @return_value = [200, {}, ["YAM"]]
+  end
+
+  def call(env)
+    @call_stack.push env.dup
+    @return_value
+  end
+end
+
 
 module RogerThemes
   class TestMiddleware < ::Test::Unit::TestCase
 
     def setup
-      @app =  proc { [200, {}, ["YAM"]] } # Yet another middleware
+      @app =  MockApp.new # Yet another middleware
       @middleware = Middleware.new @app
 
+      # Inject mock project
+      @middleware.project = Roger::Testing::MockProject.new("test/fixture")
+
       @request = Rack::MockRequest.new(@middleware)
+    end
+
+    def teardown
+      @middleware.project.destroy
     end
 
     def test_middleware_can_be_called
@@ -20,6 +45,31 @@ module RogerThemes
     def test_doesnt_touch_other_requests
       assert_equal @request.get("/my.js").body, "YAM"
     end
+
+    # Theme links work by means of rewriting the path info i.e.
+    # to render and setting the env[site_theme] var
+    def test_theme_links
+      @request.get("/themes/my-awesome-theme/theme/elements/index.html")
+      assert_equal @app.call_stack.length, 1
+      assert_equal @app.call_stack[0]["SITE_THEME"], "my-awesome-theme"
+      assert_equal @app.call_stack[0]["PATH_INFO"], "elements/index.html"
+    end
+
+    def test_shared_resources
+      # Shared resource will update the PATH_INFO to render a shared image or font
+      @app.return_value = [404, {}, ["YAM"]]
+      @request.get("/themes/my-awesome-theme/images/fancy.png")
+      assert_equal @app.call_stack.length, 2
+      assert_equal @app.call_stack[1]["PATH_INFO"], "/images/fancy.png"
+    end
+
+    def test_shared_resources_when_not_modified_is_returned
+      @app.return_value = [304, {}, ["YAM"]]
+      @request.get("/themes/my-awesome-theme/images/fancy.png")
+      assert_equal @app.call_stack.length, 1
+      assert_equal @app.call_stack[0]["PATH_INFO"], "/themes/my-awesome-theme/images/fancy.png"
+    end
+
 
   end
 end


### PR DESCRIPTION
I've added some basic cover around the env setting and also
ensured that only when a 404 error is thrown PATH_INFO rewriting is carried out.
This resolves an issue when a 304 is given we also try to render an shared resource
from the main dir instead of themes dir.
